### PR TITLE
fix double slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,8 +271,8 @@ function Jasmine2HTMLReporter(options) {
             html += specAsHtml(spec);
                 html += '<div class="resume">';
                 if (spec.screenshot !== UNDEFINED){
-                    html += '<a href="' + self.screenshotsFolder + '/' + spec.screenshot + '">';
-                    html += '<img src="' + self.screenshotsFolder + '/' + spec.screenshot + '" width="100" height="100" />';
+                    html += '<a href="' + self.screenshotsFolder + spec.screenshot + '">';
+                    html += '<img src="' + self.screenshotsFolder + spec.screenshot + '" width="100" height="100" />';
                     html += '</a>';
                 }
                 html += '<br />';


### PR DESCRIPTION
image hrefs and src contain double slashes which is shown as placeholder in chrome:

![image](https://cloud.githubusercontent.com/assets/1012324/11562822/a3c0505e-99d0-11e5-97f7-5ec1345a1b28.png)

![image](https://cloud.githubusercontent.com/assets/1012324/11562841/bbf9be9e-99d0-11e5-9b4e-8dfc30cedac8.png)

var screenshotsFolder always ends with a '/': 
https://github.com/Kenzitron/protractor-jasmine2-html-reporter/blob/master/index.js#L79
