### PR TITLE
screenshotsFolder doesn't work #24

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function Jasmine2HTMLReporter(options) {
 
 
                     //Folder structure and filename
-                    screenshotPath = path.join(self.savePath + self.screenshotsFolder, spec.screenshot);
+                    screenshotPath = path.join(self.savePath + '/' + self.screenshotsFolder, spec.screenshot);
 
                     mkdirp(path.dirname(screenshotPath), function (err) {
                         if (err) {


### PR DESCRIPTION
The parent dir and the image source dir are being concat without the / to divide them
