### PR TITLE
Framework Mentioned by default to be Jasmine2 because there are chances that it may be defaulted to be Jasmine

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ exports.config = {
 }</code></pre>
 
 ## Options
+### FrameWork
+Framework to use.
+
+<pre><code>framework: 'jasmine2',</code></pre>
+
+Default framework: <code>jasmine</code>
+
 ### Destination folder
 
 Output directory for created files. All screenshots and reports will be stored here.


### PR DESCRIPTION
Raising this up basically whenever one installs Protractor the default used is Jasmine framework, where as there are chances that it might not get with the protractor-jasmine2-html-reporter as it uses jasmine2 as such.
