### PR TITLE
Added option to retain screenshots after each test run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,22 @@ Default is <code>htmlReport.html</code>
 
 ### Consolidate and ConsolidateAll (optional)
 
-This option allow you to create diferent HTML for each test suite.
+This option allow you to create different HTML for each test suite.
 
 <pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
    consolidate: true,
    consolidateAll: true
+}));</code></pre>
+
+Default is <code>false</code>
+
+### RetainScreenshots (optional)
+
+This option, if true, will not delete the screenshots before each test run. 
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   savePath: './test/reports/',
+   retainScreenshots: true
 }));</code></pre>
 
 Default is <code>false</code>

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ function Jasmine2HTMLReporter(options) {
     self.consolidate = options.consolidate === UNDEFINED ? true : options.consolidate;
     self.consolidateAll = self.consolidate !== false && (options.consolidateAll === UNDEFINED ? true : options.consolidateAll);
     self.filePrefix = options.filePrefix || (self.consolidateAll ? 'htmlReport' : 'htmlReport-');
+    self.retainScreenshots = options.retainScreenshots === UNDEFINED ? false : options.retainScreenshots;
 
     var suites = [],
         currentSuite = null,
@@ -112,9 +113,10 @@ function Jasmine2HTMLReporter(options) {
         exportObject.startTime = new Date();
         self.started = true;
 
-        //Delete previous screenshoots
-        rmdir(self.savePath);
-
+        if(!self.retainScreenshots) {
+            // Delete previous screenshots
+            rmdir(self.savePath);
+        }
     };
     self.suiteStarted = function(suite) {
         suite = getSuite(suite);


### PR DESCRIPTION
This PR adds a `retainScreenshot` option that allows you to keep reports after a test run. I needed this because I run multiple test runs in parallel, and the report was being overwritten. 
