### PR TITLE
add cleanDirectory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,7 @@ This option, if false, will not delete the reports or screenshots before each te
 
 <pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
    savePath: './test/reports/',
-   cleanDestination: true
+   cleanDestination: false
 }));</code></pre>
+
+Default is <code>true</code>

--- a/README.md
+++ b/README.md
@@ -108,3 +108,12 @@ This option allow you to create diferent HTML for each test suite.
 }));</code></pre>
 
 Default is <code>false</code>
+
+### CleanDestination (optional)
+
+This option, if false, will not delete the reports or screenshots before each test run. 
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   savePath: './test/reports/',
+   cleanDestination: true
+}));</code></pre>

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ function Jasmine2HTMLReporter(options) {
     self.consolidate = options.consolidate === UNDEFINED ? true : options.consolidate;
     self.consolidateAll = self.consolidate !== false && (options.consolidateAll === UNDEFINED ? true : options.consolidateAll);
     self.filePrefix = options.filePrefix || (self.consolidateAll ? 'htmlReport' : 'htmlReport-');
+    self.cleanDestination = options.cleanDestination === UNDEFINED ? true : options.cleanDestination;
 
     var suites = [],
         currentSuite = null,
@@ -112,8 +113,9 @@ function Jasmine2HTMLReporter(options) {
         exportObject.startTime = new Date();
         self.started = true;
 
-        //Delete previous screenshoots
-        rmdir(self.savePath);
+        //Delete previous reports unless cleanDirectory is false
+        if (self.cleanDestination)
+            rmdir(self.savePath);
 
     };
     self.suiteStarted = function(suite) {


### PR DESCRIPTION
It can be very useful to store and archive old test runs. This unobtrusively adds an option `cleanDestination` which can be set to false, skipping over `rmdir(savePath)` and allowing persistence of tests.

If it is not set, it defaults to true, and `rmdir(savePath)` is run as usual. 

Matches the [protractor-jasmine2-screenshot-reporter](https://github.com/mlison/protractor-jasmine2-screenshot-reporter/blob/master/index.js#L315) option
