### PR TITLE
Add support for base64 inline images in html report

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ If the directory doesn't exist, it will be created automatically or otherwise cl
 
 Default folder: <code>screenshots</code>
 
+### Inline images (optional)
+
+Enabling inline images will create the html image tags with base64 encoding inline, removing the need to have a separate screenshot directory
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   savePath: './test/reports/',
+   inlineImages: true
+}));</code></pre>
+
+Default is <code>false</code>
+
 ### Take screenshots (optional)
 
 When this option is enabled, reporter will create screenshots for specs.

--- a/index.js
+++ b/index.js
@@ -79,7 +79,8 @@ function Jasmine2HTMLReporter(options) {
     self.takeScreenshots = options.takeScreenshots === UNDEFINED ? true : options.takeScreenshots;
     self.savePath = options.savePath || '';
     self.takeScreenshotsOnlyOnFailures = options.takeScreenshotsOnlyOnFailures === UNDEFINED ? false : options.takeScreenshotsOnlyOnFailures;
-    self.screenshotsFolder = (options.screenshotsFolder || 'screenshots').replace(/^\//, '') + '/';
+    self.inlineImages = options.inlineImages || '';
+    self.screenshotsFolder = options.inlineImages ? '' : (options.screenshotsFolder || 'screenshots').replace(/^\//, '') + '/';
     self.useDotNotation = options.useDotNotation === UNDEFINED ? true : options.useDotNotation;
     self.fixedScreenshotName = options.fixedScreenshotName === UNDEFINED ? false : options.fixedScreenshotName;
     self.consolidate = options.consolidate === UNDEFINED ? true : options.consolidate;
@@ -160,18 +161,22 @@ function Jasmine2HTMLReporter(options) {
 
             browser.takeScreenshot().then(function (png) {
                 browser.getCapabilities().then(function (capabilities) {
-                    var screenshotPath;
+                    if(self.inlineImages) {
+                        spec.screenshot = 'data:image/png;base64,' + png;
+                    } else {
+                        var screenshotPath;
 
 
-                    //Folder structure and filename
-                    screenshotPath = path.join(self.savePath + self.screenshotsFolder, spec.screenshot);
+                        //Folder structure and filename
+                        screenshotPath = path.join(self.savePath + self.screenshotsFolder, spec.screenshot);
 
-                    mkdirp(path.dirname(screenshotPath), function (err) {
-                        if (err) {
-                            throw new Error('Could not create directory for ' + screenshotPath);
-                        }
-                        writeScreenshot(png, screenshotPath);
-                    });
+                        mkdirp(path.dirname(screenshotPath), function (err) {
+                            if (err) {
+                                throw new Error('Could not create directory for ' + screenshotPath);
+                            }
+                            writeScreenshot(png, screenshotPath);
+                        });
+                    }                    
                 });
             });
         }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hat": "0.0.3",
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.0",
+    "q": "^1.4.1",
     "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In a continuous delivery environment, test reports might be saved in a central location (e.g. nexus, etc.) for record-keeping/tracking purposes. In the event that these types of reports are shared across teams, it would nice to be able to send failure reports (or any report for that matter) to a group using a simple url, without needing to keep up with a `screenshots` directory. Obviously, it could be sent as a zip, but this requires you to unzip it, and open the html file in the browser.

This PR adds an `inlineImages` property to the initialization options that writes the images inline using base64 encoding. Webdriver's `browser.takeScreenshot` method returns a base64 string anyway, this just uses that string in the html instead of a file reference. The result is one output html file containing the encoded screenshots. 
