### PR TITLE
added reportPassedTest, takeScreenshotsOnExpectFailures and additional prefix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ Filename for html report.
 
 Default is <code>nothing</code>
 
+### specDoneScreenshotPrefix (optional)
+
+Add a prefix to the filename for spec done screenshots.
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   specDoneScreenshotPrefix: 'SpecDone--'
+}));</code></pre>
+
+Default is <code>''</code>
+
+### expectFailedScreenshotPrefix (optional)
+
+Add a prefix to the filename for expect failed screenshots.
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   expectFailedScreenshotPrefix: 'FAIL--'
+}));</code></pre>
+
+Default is <code>''</code>
+
 ### Consolidate and ConsolidateAll (optional)
 
 This option allow you to create a single file for each reporter.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ This option, if false, will show only failures.
 
 Default is <code>true</code>
 
+### reportPassedTest (optional)
+
+This option, if false, will not generate a report if the test passes. 
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   reportPassedTest: false
+}));</code></pre>
+
+Default is <code>true</code>
+
 ### fileName (optional)
 
 This will be the name used for the html file generated thanks to this tool.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ If you disable screenshots, obviously this option will not be taken into account
 
 Default is <code>false</code> (So screenshots are always generated)
 
+### Take screenshots on except failures (optional) - (NEW)
+
+This option allows you to create screenshots on failures of specific expect statements.
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   takeScreenshotsOnExpectFailures: true
+}));</code></pre>
+
+Default is <code>false</code> (So screenshots are always generated)
+
 
 ### FixedScreenshotName (optional)
 

--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ function Jasmine2HTMLReporter(options) {
     self.fileName = options.fileName === UNDEFINED ? 'htmlReport' : options.fileName;
     self.cleanDestination = options.cleanDestination === UNDEFINED ? true : options.cleanDestination;
     self.showPassed = options.showPassed === UNDEFINED ? true : options.showPassed;
+    self.reportPassedTest = options.reportPassedTest === UNDEFINED ? true : options.reportPassedTest;
 
     var suites = [],
         currentSuite = null,
@@ -235,11 +236,15 @@ function Jasmine2HTMLReporter(options) {
         }
 
         var output = '';
+        var testFailed = false;
         for (var i = 0; i < suites.length; i++) {
             output += self.getOrWriteNestedOutput(suites[i]);
+            if (suites[i]._failures > 0) {
+                testFailed = true;
+            }
         }
         // if we have anything to write here, write out the consolidated file
-        if (output) {
+        if ((output && self.reportPassedTest) || (output && !self.reportPassedTest && testFailed)) {
             wrapOutputAndWriteFile(getReportFilename(), output);
         }
         //log("Specs skipped but not reported (entire suite skipped or targeted to specific specs)", totalSpecsDefined - totalSpecsExecuted + totalSpecsDisabled);

--- a/index.js
+++ b/index.js
@@ -107,7 +107,9 @@ function Jasmine2HTMLReporter(options) {
     self.showPassed = options.showPassed === UNDEFINED ? true : options.showPassed;
     self.reportPassedTest = options.reportPassedTest === UNDEFINED ? true : options.reportPassedTest;
     self.takeScreenshotsOnExpectFailures = options.takeScreenshotsOnExpectFailures === UNDEFINED ? false : options.takeScreenshotsOnExpectFailures;
-
+    self.specDoneScreenshotPrefix = options.specDoneScreenshotPrefix === UNDEFINED ? '' : options.specDoneScreenshotPrefix;
+    self.expectFailedScreenshotPrefix = options.expectFailedScreenshotPrefix === UNDEFINED ? '' : options.expectFailedScreenshotPrefix;
+    
     var suites = [],
         currentSuite = null,
         totalSpecsExecuted = 0,
@@ -163,7 +165,7 @@ function Jasmine2HTMLReporter(options) {
             var originalAddExpectationResult = jasmine.Spec.prototype.addExpectationResult;
             jasmine.Spec.prototype.addExpectationResult = function () {
                 if (!arguments[0]) {
-                    var failScreenshot = 'FAIL--' + sanitizeFilename(self.currentSpec.fullName) + '--' + sanitizeFilename(arguments[1].message) + '--' + hat() + '.png';
+                    var failScreenshot = self.expectFailedScreenshotPrefix + sanitizeFilename(self.currentSpec.fullName) + '--' + sanitizeFilename(arguments[1].message) + '--' + hat() + '.png';
                     browser.takeScreenshot().then(function (png) {
                         var screenshotPath = path.join(
                             self.savePath,
@@ -227,9 +229,9 @@ function Jasmine2HTMLReporter(options) {
         if ((self.takeScreenshots && !self.takeScreenshotsOnlyOnFailures) ||
             (self.takeScreenshots && self.takeScreenshotsOnlyOnFailures && isFailed(spec))) {
             if (!self.fixedScreenshotName)
-                spec.screenshot = 'SpecDone--' + hat() + '.png';
+                spec.screenshot = self.specDoneScreenshotPrefix + hat() + '.png';
             else
-                spec.screenshot = 'SpecDone--' + sanitizeFilename(spec.description) + '.png';
+                spec.screenshot = self.specDoneScreenshotPrefix + sanitizeFilename(spec.description) + '.png';
 
             browser.takeScreenshot().then(function (png) {
                 var screenshotPath = path.join(


### PR DESCRIPTION
reportPassedTest:
With my automated tests running frequently, I was looking for a way to only generate the html report if a spec/suite had a failure. Hopefully this option will be of use to someone else as well.

takeScreenshotsOnExpectFailures:
Allows for grabbing a screenshot as soon as an expect statement fails vs just at end of spec. Included in this was modifying the html report to write an array of screenshots per spec vs just one.

specDoneScreenshotPrefix & expectFailedScreenshotPrefix:
Allows for customizing a prefix to the filenames for these screenshots. I found this helpful when viewing multiple screenshots within one spec to quickly identify which one was the spec done screenshots vs expect failure screenshots.